### PR TITLE
updated npmignore to ignore build files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,6 @@
+.eslintrc
+.babelrc
+.travis.yml
 src
+test
 npm-debug.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pitchfinder",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "A pitch-detection library for node and the browser",
   "scripts": {
     "build": "rm -rf ./lib && mkdir lib && babel src -d lib",


### PR DESCRIPTION
The unneeded `.babelrc` file is caught by the React Native build tool and causes the following error: "TransformError: [_project_path_]/node_modules/pitchfinder/index.js:  Couldn't find preset \"env\" relative to directory [_project_path_]/node_modules/pitchfinder"