### PR TITLE
[AMDF] Improve rounding scheme in minPeriod/maxPeriod calculation

### DIFF
--- a/src/detectors/amdf.js
+++ b/src/detectors/amdf.js
@@ -12,6 +12,11 @@ module.exports = function(config = {}) {
   const sensitivity = config.sensitivity || DEFAULT_SENSITIVITY;
   const ratio = config.ratio || DEFAULT_RATIO;
   const amd = [];
+
+  /* Round in such a way that both exact minPeriod as 
+   exact maxPeriod lie inside the rounded span minPeriod-maxPeriod,
+   thus ensuring that minFrequency and maxFrequency can be found
+   even in edge cases */
   const maxPeriod = Math.ceil(sampleRate / minFrequency);
   const minPeriod = Math.floor(sampleRate / maxFrequency);
 

--- a/src/detectors/amdf.js
+++ b/src/detectors/amdf.js
@@ -12,8 +12,8 @@ module.exports = function(config = {}) {
   const sensitivity = config.sensitivity || DEFAULT_SENSITIVITY;
   const ratio = config.ratio || DEFAULT_RATIO;
   const amd = [];
-  const maxPeriod = Math.round(sampleRate / minFrequency + 0.5);
-  const minPeriod = Math.round(sampleRate / maxFrequency + 0.5);
+  const maxPeriod = Math.ceil(sampleRate / minFrequency);
+  const minPeriod = Math.floor(sampleRate / maxFrequency);
 
   return function AMDFDetector (float32AudioBuffer) {
     "use strict";

--- a/test/index.js
+++ b/test/index.js
@@ -36,7 +36,41 @@ describe("Pitchfinder", () => {
         });
       });
     });
+  });
 
+  describe("AMDF minimum/maximum frequency parameters", () => {
+    const detector = (minFreq, maxFreq) => Pitchfinder.AMDF({
+      minFrequency : minFreq,
+      maxFrequency : maxFreq});
+      pitchSamples.forEach((fileName) => {
+        const [hz, type] = fileName.replace(".wav", "").split("_");
+	const hz_numb = Number(hz);
+	const freqOffset = 100;
+	const params = [
+	  {
+            minFreq : hz_numb,
+            maxFreq : hz_numb+freqOffset
+	  },
+	  {
+            minFreq : hz_numb-freqOffset,
+	    maxFreq : hz_numb
+	  }
+        ];
+        params.forEach((freqs) => {
+          const minFreq = freqs.minFreq;
+          const maxFreq = freqs.maxFreq;
+          it(`Detects ${type} wave at ${hz} hz with minimumFrequency ${minFreq} hz and maximumFrequency ${maxFreq} hz`, () => {
+            return fs.readFile(path("pitches", fileName))
+              .then(decode)
+              .then(detector(minFreq, maxFreq))
+              .then((pitch) => {
+                if (pitch == null) throw new Error("No frequency detected");
+                const diff = Math.abs(pitch - hz_numb);
+                if (diff > 10) throw new Error(`Too large an error - detected wave at ${hz} as ${pitch} hz`);
+              });
+           });
+        });
+     });
   });
 
   describe("Frequencies tool", () => {


### PR DESCRIPTION
Line 16 in current master's amdf.js
`const minPeriod = Math.round(sampleRate / maxFrequency + 0.5);`
does always round up resp. even increments minPeriod by one for whole numbers.
Rounded minPeriod however should never be greater than exact minPeriod in order to catch 
a periodicity at maxFrequency.
This PR changes the rounding scheme to round minPeriod always down and maxPeriod always up.
It makes use of the functions Math.ceil() and Math.floor(), which are more self-documenting as 
Math.round(foo+0.5).
Additionately it does add a mocha test with cases where minFrequency or maxFrequency equal to the 
frequency sought after.